### PR TITLE
Re-enable actions only if edit-save succeeded

### DIFF
--- a/js/insert.js
+++ b/js/insert.js
@@ -164,7 +164,9 @@ function edit_link_save(id) {
 			feedback(data.message, data.status);
 			end_loading("#edit-close-" + id);
 			end_disable("#edit-close-" + id);
-			end_disable("#actions-" + id + ' .button');
+			if(data.status == 'success') {
+				end_disable("#actions-" + id + ' .button');
+			}
 		}
 	);
 }


### PR DESCRIPTION
Fixes a flaw in `edit_link_save()` in insert.js:

On exit, `edit_link_save()` re-enables all buttons of the action column, regardless of the value of `status` as returned by the ajax call (`action=edit_save`), i.e. also if the `status` is `fail` which means that the edit row remains visible. Because of that, it is then possible to open another edit row for the same keyword/long URL row. It is even possible to repeat this, introducing an arbitrary number of open edit rows with the same content.

The flaw exists at least since v1.7.0 (and even though it is only a flaw, it should probably be fixed to stop users from messing things up).

To reproduce the problem on e.g. a fresh install, click the edit button of an arbitrary row of the table in the admin panel. Then, without editing anything(!), click the save button. You will get the correct notification 'Error updating {trimmed longurl} Short URL: {untrimmed keyword}' because there is nothing (i.e. no change) to save yet. The edit row remains visible, and the corresponding action buttons get re-enabled. Now click the edit button to open a new edit row. Repetition (i.e., provoking failure again by clicking the save button in one of the open edit rows w/o having anything edited before, and so on) will introduce more redundant edit rows. 

Fix: Instead of unconditionally enabling the action buttons, this is now done only if the edit row has been faded out before (i.e., if `data.status` equals `success`).
